### PR TITLE
fix: tab name and site name on navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script src="https://kit.fontawesome.com/857cc553ce.js" crossorigin="anonymous"></script>
-    <title>Vite + React + TS</title>
+    <title>Shoply</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/shared/navbar.tsx
+++ b/src/components/shared/navbar.tsx
@@ -16,7 +16,7 @@ export default function Navbar() {
           {/* Logo */}
           <Link to="/" className="flex items-center hover:cursor-pointer">
             <ShoppingCart className="size-8 text-sky-600" />
-            <h1 className="ml-3 text-2xl font-bold text-gray-900">Shoplify</h1>
+            <h1 className="ml-3 text-2xl font-bold text-gray-900">Shoply</h1>
           </Link>
 
           {/* Categories */}


### PR DESCRIPTION
Very minor fix. Wanted the tab to say Shoply instead of Vive + React. Also I'm not sure why the site name on the navbar was changed to "Shoplify" but I changed it (back?) to Shoply.